### PR TITLE
Make pypm compatible with both Python 2.7 and Python 3

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,3 +1,6 @@
+from pypm import dump, freeze_traceback
+
+
 def f():
     adam = 3
     beta = 4
@@ -6,13 +9,13 @@ def f():
     epsilon = {'a': [1,2,3,4]}
     raise ValueError('hey')
 
-if __name__ == '__main__':
-    from pypm import dump, freeze_traceback
 
+if __name__ == '__main__':
     try:
         f()
     except Exception as ex:
-        with open('test.dump', 'wb') as f:
+        dump_file = 'test.dump'
+        with open(dump_file, 'wb') as f:
+            print("Exception caught, writing dump to %s" % dump_file)
             dump(freeze_traceback(), f)
-
-        raise ex
+            print("Run 'python -m pypm [--debugger <pdb|pudb|ipdb>] %s' to debug" % (dump_file))

--- a/pypm/__init__.py
+++ b/pypm/__init__.py
@@ -1,1 +1,1 @@
-from pypm.pypm import *
+from .pypm import *

--- a/pypm/__main__.py
+++ b/pypm/__main__.py
@@ -2,7 +2,7 @@ import sys
 import argparse
 import importlib
 
-from pypm import *
+from .pypm import debug, load
 
 
 def parse_args():
@@ -22,4 +22,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/pypm/__main__.py
+++ b/pypm/__main__.py
@@ -8,7 +8,7 @@ from pypm import *
 def parse_args():
     parser = argparse.ArgumentParser('pypm - post_mortem debugging of python dumps using pypm.save_dump')
     parser.add_argument('dump', help='Path to the dump file')
-    parser.add_argument('--debugger', default='pdb', help='Debugger to use (must implement `post_morgem`)')
+    parser.add_argument('--debugger', default='pdb', help='Debugger to use (must implement `post_mortem`)')
     return parser.parse_args()
 
 def _debug(debugger, dump_file):

--- a/pypm/pypm.py
+++ b/pypm/pypm.py
@@ -183,8 +183,16 @@ def debug(frozen_traceback):
 
 class NotPickled(object):
 
-    def __init__(self, txt):
-        self.__str__ = lambda x: '<NotPickled: %s>' % txt
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(NotPickled)
+        obj.__init__(*args, **kwargs)
+        return obj
+
+    def __init__(self, txt=''):
+        self.txt = txt
+
+    def __str__(self):
+        return '<NotPickled: %s>' % self.txt
 
 
 class FakeCode(object):

--- a/pypm/pypm.py
+++ b/pypm/pypm.py
@@ -29,7 +29,10 @@ import linecache
 import inspect
 import dill
 from contextlib import contextmanager
-import StringIO
+try:
+    from StringIO import StringIO as FakeFile
+except ImportError:
+    from io import BytesIO as FakeFile
 
 __version__ = "2.0b4"
 __all__ = ["freeze_traceback", "dump", "dumps", "load", "loads", "debug",
@@ -61,14 +64,14 @@ class FrozenTraceback(object):
 
     def to_bytes(self):
         with _monkeypatch_pickle_save():
-            bytes_out = StringIO.StringIO()
+            bytes_out = FakeFile()
             with gzip.GzipFile(fileobj=bytes_out, mode='w') as outfile:
                 outfile.write(dill.dumps(self))
             return bytes_out.getvalue()
 
     @staticmethod
     def from_bytes(b):
-        bytes_in = StringIO.StringIO(b)
+        bytes_in = FakeFile(b)
         with gzip.GzipFile(fileobj=bytes_in, mode='r') as infile:
             return dill.loads(infile.read())
 

--- a/pypm/pypm.py
+++ b/pypm/pypm.py
@@ -41,6 +41,11 @@ __all__ = ["freeze_traceback", "dump", "dumps", "load", "loads", "debug",
 
 exceptions_to_trigger = {}
 builtin_sys_excepthook = sys.excepthook
+if hasattr(pickle, '_dumps'):
+    # force the pickle module to use the pure Python implementation so that
+    # we can later monkeypatch it
+    pickle.dumps = pickle._dumps
+    pickle.dump = pickle._dump
 pickler_module = getattr(pickle, '_Pickler', pickle.Pickler)
 builtin_pickle_save = getattr(pickler_module, 'save')
 

--- a/pypm/pypm.py
+++ b/pypm/pypm.py
@@ -244,16 +244,22 @@ def _cache_files(files):
 
 def _pickle_save(f):
     def _save(self, obj, save_persistent_id=True):
+        not_pickled_obj = NotPickled(repr(obj))
         try:
-            f(self, obj, save_persistent_id)
-        except TypeError:
-            f(self, obj)
+            f(self, obj, save_persistent_id=save_persistent_id)
+        except TypeError as err:
+            if 'unexpected keyword argument' in str(err):
+                try:
+                    f(self, obj)
+                except Exception:
+                    f(self, not_pickled_obj)
+            else:
+                f(self, not_pickled_obj, save_persistent_id=save_persistent_id)
         except Exception:
-            obj = NotPickled(obj.__repr__())
             try:
-                f(self, obj, save_persistent_id)
+                f(self, not_pickled_obj, save_persistent_id=save_persistent_id)
             except TypeError:
-                f(self, obj)
+                f(self, not_pickled_obj)
 
     return _save
 


### PR DESCRIPTION
This change allows pypm to work simultaneously on Python 2.7 and Python 3 (tested with 2.7.13 and 3.5.3)

Python 2.7:
```
$ python --version
Python 2.7.13
$ python example.py
Exception caught, writing dump to test.dump
Run 'python -m pypm [--debugger <pdb|pudb|ipdb>] test.dump' to debug
$ python -m pypm test.dump
> /mnt/c/Users/robert/pypm/example.py(10)f()
-> raise ValueError('hey')
(Pdb) l
  5         adam = 3
  6         beta = 4
  7         theta = lambda x: x**2
  8         delta = range(10)
  9         epsilon = {'a': [1,2,3,4]}
 10  ->     raise ValueError('hey')
 11
 12
 13     if __name__ == '__main__':
 14         try:
 15             f()
(Pdb) theta
<function <lambda> at 0x7f328a7609b0>
(Pdb) beta
4
(Pdb) q
$
```

Python 3.5:
```
$ python3 --version
Python 3.5.3
$ python3 example.py
Exception caught, writing dump to test.dump
Run 'python -m pypm [--debugger <pdb|pudb|ipdb>] test.dump' to debug
$ python3 -m pypm test.dump
> /mnt/c/Users/robert/pypm/example.py(10)f()
-> raise ValueError('hey')
(Pdb) l
  5  >>     adam = 3
  6         beta = 4
  7         theta = lambda x: x**2
  8         delta = range(10)
  9         epsilon = {'a': [1,2,3,4]}
 10  ->     raise ValueError('hey')
 11
 12
 13     if __name__ == '__main__':
 14         try:
 15             f()
(Pdb) theta
<function <lambda> at 0x7f9591c15bf8>
(Pdb) beta
4
(Pdb) q
$
```

Also fixed a typo in `__main__.py` where post_mortem was incorrectly spelled as post_morgem.